### PR TITLE
Missing @Inject annotation

### DIFF
--- a/backend/src/main/java/com/api/backend/SampleResource.java
+++ b/backend/src/main/java/com/api/backend/SampleResource.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("sample")
 public class SampleResource {
 
+	@Inject
 	@ConfigProperty(name = "message")
 	private String message;
 


### PR DESCRIPTION
When using the @ConfigProperty annotation from Microprofile on a field, the field must be annotated with @Inject.